### PR TITLE
Fix: FIFA TokenScript attribute definition and views

### DIFF
--- a/skstravel.cn/2019/05/fifa.tsml
+++ b/skstravel.cn/2019/05/fifa.tsml
@@ -27,42 +27,54 @@
 
     <ts:cards>
         <ts:token-card>
-            <style type="text/css">body {
-  font-family: Arial;
-    }
-table {
-  margin: 25px;
-  width: 25%;
-  table-layout: auto;
-    }
-.fixed {
-  table-layout: fixed;
-    }
-table,
-td,
-th {
-  border-collapse: collapse;
-    }
-th,
-td {
-  border: solid 0px;
-  text-align: left;
-    }
-form {
-  display: flex;
-  align-items: center;
-    }
-input {
-  background-color: #FFFFFF;
-  border: #D8D8D8 solid 1px;
-  border-radius: 6px;
-  padding: 0.5em;
-  width: 25%;
-  height: 30px;
-  margin-top: 5px;
-  font-size: 1em;
-    }
-</style>
+          <style type="text/css">
+            .tbml-count {
+              font-family: "SourceSansPro";
+              font-weight: bolder;
+              font-size: 21px;
+              color: rgb(117, 185, 67);
+            }
+            .tbml-category {
+              font-family: "SourceSansPro";
+              font-weight: lighter;
+              font-size: 21px;
+              color: rgb(67, 67, 67);
+            }
+            .tbml-venue {
+              font-family: "SourceSansPro";
+              font-weight: lighter;
+              font-size: 16px;
+              color: rgb(67, 67, 67);
+            }
+            .tbml-date {
+              font-family: "SourceSansPro";
+              font-weight: bold;
+              font-size: 14px;
+              color: rgb(112, 112, 112);
+              margin-left: 7px;
+              margin-right: 7px;
+            }
+            .tbml-time {
+              font-family: "SourceSansPro";
+              font-weight: lighter;
+              font-size: 16px;
+              color: rgb(112, 112, 112);
+            }
+            html {
+            }
+            body {
+              padding: 0px;
+              margin: 0px;
+            }
+            div {
+              margin: 0px;
+              padding: 0px;
+            }
+            .data-icon {
+              height:16px;
+              vertical-align: middle
+            }
+          </style>
             <ts:view-iconified xml:lang="en">
                 <script type="text/javascript" xml:base="file:///Users/sangalli/Documents/projects/TokenScript/examples/fifa/fifa.en.shtml">
     (function() {
@@ -206,6 +218,7 @@ web3.tokens.dataChanged = (oldTokens, updatedTokens) => {
 
 ]]></script>
 
+              <div id="root"/>
             </ts:view-iconified>
             <ts:view xml:lang="en">
                 <script type="text/javascript" xml:base="file:///Users/sangalli/Documents/projects/TokenScript/examples/fifa/fifa.en.shtml">
@@ -350,6 +363,7 @@ web3.tokens.dataChanged = (oldTokens, updatedTokens) => {
 
 ]]></script>
 
+              <div id="root"/>
             </ts:view>
         </ts:token-card>
         <ts:action>
@@ -366,42 +380,6 @@ web3.tokens.dataChanged = (oldTokens, updatedTokens) => {
                 <ts:string xml:lang="es">Entrar</ts:string>
             </ts:name>
             <ts:exclude selection="expired"/>
-            <style type="text/css">body {
-  font-family: Arial;
-    }
-table {
-  margin: 25px;
-  width: 25%;
-  table-layout: auto;
-    }
-.fixed {
-  table-layout: fixed;
-    }
-table,
-td,
-th {
-  border-collapse: collapse;
-    }
-th,
-td {
-  border: solid 0px;
-  text-align: left;
-    }
-form {
-  display: flex;
-  align-items: center;
-    }
-input {
-  background-color: #FFFFFF;
-  border: #D8D8D8 solid 1px;
-  border-radius: 6px;
-  padding: 0.5em;
-  width: 25%;
-  height: 30px;
-  margin-top: 5px;
-  font-size: 1em;
-    }
-</style>
             <ts:view xml:lang="en">
                 <script type="text/javascript" xml:base="file:///Users/sangalli/Documents/projects/TokenScript/examples/fifa/fifa.en.shtml">
     (function() {
@@ -545,6 +523,7 @@ web3.tokens.dataChanged = (oldTokens, updatedTokens) => {
 
 ]]></script>
 
+              <div id="root"/>
             </ts:view>
         </ts:action>
     </ts:cards>
@@ -618,7 +597,7 @@ web3.tokens.dataChanged = (oldTokens, updatedTokens) => {
                 <ts:string xml:lang="ru">город</ts:string>
             </ts:name>
             <ts:origins>
-                <ts:token-id as="utf8" bitmask="00000000000000000000000000000000FF000000000000000000000000000000">
+                <ts:token-id as="uint" bitmask="00000000000000000000000000000000FF000000000000000000000000000000">
                     <ts:mapping>
                         <ts:option key="1">
                             <ts:value xml:lang="ru">Москва́</ts:value>
@@ -699,7 +678,7 @@ web3.tokens.dataChanged = (oldTokens, updatedTokens) => {
                 <ts:string xml:lang="ru">место встречи</ts:string>
             </ts:name>
             <ts:origins>
-                <ts:token-id as="utf8" bitmask="0000000000000000000000000000000000FF0000000000000000000000000000">
+                <ts:token-id as="uint" bitmask="0000000000000000000000000000000000FF0000000000000000000000000000">
                     <ts:mapping>
                         <ts:option key="1">
                             <ts:value xml:lang="ru">Стадион Калининград</ts:value>
@@ -822,7 +801,7 @@ web3.tokens.dataChanged = (oldTokens, updatedTokens) => {
                 <ts:string xml:lang="es">Cat</ts:string>
             </ts:name>
             <ts:origins>
-                <ts:token-id as="utf8" bitmask="0000000000000000000000000000000000000000000000000000000000FF0000">
+                <ts:token-id as="uint" bitmask="0000000000000000000000000000000000000000000000000000000000FF0000">
                     <ts:mapping>
                         <ts:option key="1">
                             <ts:value xml:lang="en">Category 1</ts:value>


### PR DESCRIPTION
This PR:

* Fixes attributes that has a token-id origin and mapping. The origin should be `as="uint"` not `as="utf8"`
* Add <div id="root"/> to each view (which is then programmatically replaced with JavaScript)
* Fixed styles

@James-Sangalli I don't know if there's a repo for the source .xml file. Can you help to sign it? I have another related PR #10  affecting the same file. Kept them separate so you can apply them conditionally.